### PR TITLE
Update github demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## The Lorenz Attractor in Godot!
 
-[Demo in browser](https://aith.github.io/attractor-godot/)  \
+[Demo in browser](https://emraine.github.io/attractor-godot/)  \
 The Lorenz Attractor is famous for being a chaotic system, and giving math textbooks pretty covers!  \
 Here's a simple implementation in Godot 3.3 using particle shaders.  \
 ![gif](attractor.gif)


### PR DESCRIPTION
You're still linked to your old GitHub name.  The demo link in the repo description is also broken now.  Also applied to a bunch of your other repos' about links.